### PR TITLE
NATIVE-246: Fix deadlock on master node

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ void uploadToBrowserstack(String path) {
 }
 
 pipeline {
-    agent any
+    agent none
     options {
         timeout(time: 1, unit: 'HOURS')
         skipDefaultCheckout()

--- a/e2e/driver/driver.js
+++ b/e2e/driver/driver.js
@@ -17,7 +17,7 @@ const capsName = process.env.E2E_CAPS || defaultCaps
 
 const BROWSERSTACK_EXHAUSTED_MESSAGE = 'All parallel tests are currently in use, including the queued tests. ' +
   'Please wait to finish or upgrade your plan to add more sessions.'
-const IMPLICIT_WAIT_TIMEOUT = 2000
+const IMPLICIT_WAIT_TIMEOUT = 10000
 const INIT_RETRY_TIME = 3000
 const STARTUP_DELAY = 3000
 


### PR DESCRIPTION
When more jobs are started than there are executors at the same time no job can finish.

This is because currently an other executor is needed to run the compilation. One is used as supervisor.