### PR TITLE
NATIVE-88: Switch fallback order for non-arabic glyphs

### DIFF
--- a/src/modules/theme/constants/fonts.js
+++ b/src/modules/theme/constants/fonts.js
@@ -23,7 +23,7 @@ export const arabicFonts: FontsType = { // used for 'ar', 'fa' and 'ku'
   decorativeLineHeight: 1.3,
   contentFontRegular: 'OpenSans-Regular',
   contentFontBold: 'OpenSans-Bold',
-  webviewFontFamilies: `'Lateef', 'OpenSans', sans-serif`,
+  webviewFontFamilies: `'OpenSans', 'Lateef', sans-serif`,
   contentFontSize: '0.95rem',
   contentLineHeight: 1.4,
   standardParagraphMargin: '0.75rem',


### PR DESCRIPTION
One last commit for custom-fonts:
I needed to switch the font-fallback order for non-arabic glyphs to be displayed with OpenSans and not the Lateef-builtin ones (because these are ugly).