### PR TITLE
NATIVE-507: Adjustments for CD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,10 +34,12 @@ workflows:
           production: << pipeline.parameters.production >>
           requires:
             - build_android
+            - bump_version
       - deliver_ios:
           production: << pipeline.parameters.production >>
           requires:
             - build_ios
+            - bump_version
       - bump_version:
           requires: # Bump version should only depend on build_ and not delivery_. Sometimes upload to the stores fails only for iOS or Android. Then we still should bump the version
             - build_android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,13 +58,17 @@ workflows:
       - build_ios:
           e2e_build: false
       - deliver_android:
+          type: approval
           production: false
           requires:
             - build_android
+            - bump_version
       - deliver_ios:
+          type: approval
           production: false
           requires:
             - build_ios
+            - bump_version
       - bump_version:
           requires: # Bump version should only depend on build_ and not delivery_. Sometimes upload to the stores fails only for iOS or Android. Then we still should bump the version
             - build_android
@@ -83,13 +87,17 @@ workflows:
       - build_ios:
           e2e_build: false
       - deliver_android:
+          type: approval
           production: true
           requires:
             - build_android
+            - bump_version
       - deliver_ios:
+          type: approval
           production: true
           requires:
             - build_ios
+            - bump_version
       - bump_version:
           requires: # Bump version should only depend on build_ and not delivery_. Sometimes upload to the stores fails only for iOS or Android. Then we still should bump the version
             - build_android

--- a/.circleci/trigger-pipeline.sh
+++ b/.circleci/trigger-pipeline.sh
@@ -39,15 +39,18 @@ done
 # set positional arguments in their proper place
 eval set -- "$PARAMS"
 
-curl -v -X POST https://circleci.com/api/v2/project/github/Integreat/integreat-react-native-app/pipeline \
+
+post_data="
+    {
+      \"branch\": \"$branch\",
+      \"parameters\": {
+        \"api_triggered\": true,
+        \"production\": $production
+      }
+    }"
+
+curl -X POST https://circleci.com/api/v2/project/github/Integreat/integreat-react-native-app/pipeline \
   -H "Content-Type: application/json" \
   -H "Accept: application/json" \
   -H "Circle-Token: ${api_token}" \
-   --data "
-  {
-    \"branch\": \"$branch\",
-    \"parameters\": {
-      \"api_triggered\": true,
-      \"production\": false
-    }
-  }"
+   --data $post_data

--- a/android/fastlane/Fastfile
+++ b/android/fastlane/Fastfile
@@ -14,7 +14,7 @@ KEYSTORE_KEY_PASSWORD = ENV['KEYSTORE_KEY_PASSWORD'] || '123456'
 desc "Prepare the keystore"
 lane :keystore do
   ensure_env_vars(
-      env_vars: ['CREDENTIALS_GIT_REPOSITORY_URL']
+      env_vars: ['CREDENTIALS_GIT_REPOSITORY_URL', 'CREDENTIALS_KEYSTORE_PATH', 'CREDENTIALS_DIRECTORY_PATH', 'CREDENTIALS_KEYSTORE_PASSWORD']
   )
 
   puts("Cloning repository with keystore")

--- a/docs/08-cicd.md
+++ b/docs/08-cicd.md
@@ -17,6 +17,26 @@
 
 # Manual deployment
 
+## iOS
+
+## Android
+
+`export CREDENTIALS_GIT_REPOSITORY_URL=<secret>`
+`export CREDENTIALS_DIRECTORY_PATH=/tmp/credentials`
+`export CREDENTIALS_KEYSTORE_PASSWORD=<secret>`
+`export CREDENTIALS_KEYSTORE_PATH=/tmp/credentials/<secret>.enc`
+`export KEYSTORE_PATH=/tmp/keystore.jks`
+`fastlane keystore`
+
+`export KEYSTORE_KEY_ALIAS=<secret>`
+`export KEYSTORE_PASSWORD=<secret>`
+`export KEYSTORE_KEY_PASSWORD=<secret>`
+`fastlane build`
+
+`adb install app/build/outputs/apk/release/app-release.apk`
+`adb shell am force-stop tuerantuer.app.integreat`
+`adb shell am start -n tuerantuer.app.integreat/.MainActivity`
+
 ## Setup environment variables locally
 
 # Credentials and services
@@ -28,6 +48,7 @@
 Access to the Bot is granted by a Private Key in PEM format. This is used to get an access token for an installation. This access_token allows to write content to the repositories/organisations where it was installed.
 
 // PEM is base64 encoded
+// Disable "Include Administrators" in Protected Branches (GitHub App is Admin)
 
 
 ## Google Play Store

--- a/version.yml
+++ b/version.yml
@@ -1,3 +1,3 @@
 ---
-version_name: 2020.4.13
-version_code: 100025
+version_name: 2020.4.14
+version_code: 100026


### PR DESCRIPTION


I made a few minor mistakes. These should be fixed in this branch:

   

- Require approval for releases (required until NATIVE-504)
- Trigger script does deploy to beta always
- deliverino can not bump the version

