### PR TITLE
NATIVE-417: share button only displayed with existing sharePath

### DIFF
--- a/src/modules/layout/components/Header.js
+++ b/src/modules/layout/components/Header.js
@@ -97,7 +97,7 @@ class Header extends React.PureComponent<PropsType> {
 
   onShare = async () => {
     const { navigation, t } = this.props
-    const sharePath: ?string = navigation.getParam('sharePath')
+    const sharePath: string = navigation.getParam('sharePath')
     const url = `https://integreat.app${sharePath}`
     const message = t('shareMessage', { message: url, interpolation: { escapeValue: false } })
 

--- a/src/modules/layout/components/Header.js
+++ b/src/modules/layout/components/Header.js
@@ -98,9 +98,6 @@ class Header extends React.PureComponent<PropsType> {
   onShare = async () => {
     const { navigation, t } = this.props
     const sharePath: ?string = navigation.getParam('sharePath')
-    if (!sharePath) {
-      return console.error('sharePath is undefined')
-    }
     const url = `https://integreat.app${sharePath}`
     const message = t('shareMessage', { message: url, interpolation: { escapeValue: false } })
 
@@ -155,7 +152,7 @@ class Header extends React.PureComponent<PropsType> {
           this.renderItem(t('search'), 'search', 'always', this.goToSearch, t('search'))}
           {!peeking && goToLanguageChange &&
           this.renderItem(t('changeLanguage'), 'language', 'always', goToLanguageChange, t('changeLanguage'))}
-          {this.renderItem(t('share'), undefined, 'never', sharePath ? this.onShare : undefined, t('share'))}
+          {sharePath && this.renderItem(t('share'), undefined, 'never', this.onShare, t('share'))}
           {this.renderItem(t('changeLocation'), undefined, 'never', this.goToLanding, t('changeLocation'))}
           {this.renderItem(t('settings'), undefined, 'never', this.goToSettings, t('settings'))}
           {this.renderItem(t('disclaimer'), undefined, 'never', this.goToDisclaimer, t('disclaimer'))}


### PR DESCRIPTION
Issue description: An alert is currenlty showed to the user: https://github.com/Integreat/integreat-react-native-app/blob/564348e92000bbb3caee25737136307aeaffd8a9/src/modules/layout/components/Header.js#L119
The share button should not be displayed in this case.

Now: The share button is only displayed if the sharepath is defined