### PR TITLE
NATIVE-608: Fixed Windows' Yarn-Path error by using OS conditions

### DIFF
--- a/android/app/buildConfigs.gradle
+++ b/android/app/buildConfigs.gradle
@@ -12,7 +12,12 @@ def determineBuildConfigName() {
 def createBuildConfig(buildConfigName) {
     logger.quiet("Using build config $buildConfigName")
 
-    def command = "yarn --silent babel-node tools/build-config to-json $buildConfigName"
+    def command
+    if (System.properties['os.name'].toLowerCase().contains('windows')) {
+        command = ["cmd", "/c", "yarn --silent babel-node tools/build-config to-json $buildConfigName"]
+    } else {
+        command = "yarn --silent babel-node tools/build-config to-json $buildConfigName"
+    }
     def proc = command.execute()
     proc.waitFor()
 
@@ -48,7 +53,12 @@ def setupGoogleServices(buildConfig, resValue) {
 }
 
 def setupResourceValues(buildConfigName, resValue) {
-    def command = "yarn --silent babel-node tools/build-config to-xcconfig $buildConfigName"
+    def command
+    if (System.properties['os.name'].toLowerCase().contains('windows')) {
+        command = ["cmd", "/c", "yarn --silent babel-node tools/build-config to-xcconfig $buildConfigName"]
+    } else {
+        command = "yarn --silent babel-node tools/build-config to-xcconfig $buildConfigName"
+    }
     def proc = command.execute()
     proc.waitFor()
 


### PR DESCRIPTION
This pull request belongs to an issue on our [bugtracker](https://issues.integreat-app.de/).
You can find it there by looking for an issue with the key which is mentioned in the title of this pull request.
It starts with the keyword **NATIVE**.
